### PR TITLE
Removes MSG_DONTROUTE flag from socket_sendto call

### DIFF
--- a/Phpwol/Socket.php
+++ b/Phpwol/Socket.php
@@ -9,7 +9,7 @@ class Socket {
     // If, for example, the broadcast IP is not on a network that the machine is attached to then
     // socket_sendto will fail with an error. It's difficult to check for that scenario when a machine has
     // multiple interfaces so just silence the error and return false.
-    $sentBytes = @socket_sendto($socket, $data, strlen($data), MSG_DONTROUTE, $broadcastIP, $port);
+    $sentBytes = @socket_sendto($socket, $data, strlen($data), 0, $broadcastIP, $port);
     socket_close($socket);
 
     if ($sentBytes === false){


### PR DESCRIPTION
That enables us to send the magic packet to 255.255.255.255.

Fixes #2.